### PR TITLE
add disable_wrap_height_check option to pdf.text_box

### DIFF
--- a/lib/prawn/text/box.rb
+++ b/lib/prawn/text/box.rb
@@ -93,6 +93,9 @@ module Prawn
     #     <tt>number</tt>. The minimum font size to use when :overflow is set to
     #     :shrink_to_fit (that is the font size will not be reduced to less than
     #     this value, even if it means that some text will be cut off). [5]
+    # <tt>:disable_wrap_height_check</tt>::
+    #     <tt>boolean</tt>. If true, then truncated text would render even if 
+    #     text height exceeds field height [false]
     #
     # == Returns
     #

--- a/lib/prawn/text/formatted/box.rb
+++ b/lib/prawn/text/formatted/box.rb
@@ -146,6 +146,7 @@ module Prawn
 
           @overflow = options[:overflow] || :truncate
           @disable_wrap_by_char = options[:disable_wrap_by_char]
+          @disable_wrap_height_check = options[:disable_wrap_height_check]
 
           self.original_text = formatted_text
           @text = nil

--- a/lib/prawn/text/formatted/wrap.rb
+++ b/lib/prawn/text/formatted/wrap.rb
@@ -22,6 +22,7 @@ module Prawn
             kerning: options[:kerning]
           )
           @disable_wrap_by_char = options[:disable_wrap_by_char]
+          @disable_wrap_height_check = options[:disable_wrap_height_check]
         end
 
         # See the developer documentation for PDF::Core::Text#wrap
@@ -60,7 +61,7 @@ module Prawn
               disable_wrap_by_char: @disable_wrap_by_char
             )
 
-            if enough_height_for_this_line?
+            if @disable_wrap_height_check || enough_height_for_this_line?
               move_baseline_down
               print_line
             else


### PR DESCRIPTION
that ignores height overflows and will always print texts
even if its larger than field heigh